### PR TITLE
Replace € and ™

### DIFF
--- a/layouts/USA plus.bundle/Contents/Resources/USA plus.keylayout
+++ b/layouts/USA plus.bundle/Contents/Resources/USA plus.keylayout
@@ -398,7 +398,7 @@
 			<key code="16" output="¥"/>
 			<key code="17" output="†"/>
 			<key code="18" output="¡"/>
-			<key code="19" output="™"/>
+			<key code="19" output="€"/>
 			<key code="20" output="£"/>
 			<key code="21" output="¢"/>
 			<key code="22" output="§"/>
@@ -510,7 +510,7 @@
 			<key code="16" output="Á"/>
 			<key code="17" output="ˇ"/>
 			<key code="18" output="⁄"/>
-			<key code="19" output="€"/>
+			<key code="19" output="™"/>
 			<key code="20" output="‹"/>
 			<key code="21" output="›"/>
 			<key code="22" output="ﬂ"/>
@@ -622,7 +622,7 @@
 			<key code="16" output="Á"/>
 			<key code="17" output="†"/>
 			<key code="18" output="¡"/>
-			<key code="19" output="™"/>
+			<key code="19" output="€"/>
 			<key code="20" output="£"/>
 			<key code="21" output="¢"/>
 			<key code="22" output="§"/>
@@ -734,7 +734,7 @@
 			<key code="16" output="¥"/>
 			<key code="17" output="†"/>
 			<key code="18" output="¡"/>
-			<key code="19" output="™"/>
+			<key code="19" output="€"/>
 			<key code="20" output="£"/>
 			<key code="21" output="¢"/>
 			<key code="22" output="§"/>


### PR DESCRIPTION
This PR allows to easily produce the character "€" by pressing <kbd>Option</kbd>+<kbd>2</kbd>, which was previously assigned to the less useful ™ symbol.

It is still possible to write ™ by pressing the key combinations that currently produce €, i.e. <kbd>Option</kbd>+<kbd>Shift</kbd>+<kbd>2</kbd>.

(untested, but should be straightforward)